### PR TITLE
Fix Broken Links to Kernel Concepts Shop

### DIFF
--- a/fan-artikel.html
+++ b/fan-artikel.html
@@ -62,14 +62,14 @@
     	</p>
     	<table id="table_fan">
     		<tr>
-    			<td><a target="_blank" href="http://shop.kernelconcepts.de/product_info.php?products_id=118"><img width="80px" src="img/osm-pin.jpg" alt="OSM-Pin" title="Pin mit OSM-Logo"/></a></td>
+				<td><a target="_blank" href="http://shop.kernelconcepts.de/#osm"><img width="80px" src="img/osm-pin.jpg" alt="OSM-Pin" title="Pin mit OSM-Logo"/></a></td>
     			<td class="span9">Pin mit OpenStreetMap-Logo. Der Pin ist ca. 1,5cm hoch und 2cm breit und in der Form des Logos ausgeschnitten.</td>
-    			<td>1,50€ (inkl. 0,50€ Spende)<br/><a target="_blank" href="http://shop.kernelconcepts.de/product_info.php?products_id=118">Zum Shop</a></td>
+				<td>1,50€ (inkl. 0,50€ Spende)<br/><a target="_blank" href="http://shop.kernelconcepts.de/">Zum Shop</a></td>
     		</tr>
     		<tr>
-    			<td><a target="_blank" href="http://shop.kernelconcepts.de/product_info.php?products_id=112"><img width="80px" src="img/tasse-big.png" alt="OSM-Tasse" title="OSM Cheat Mug"/></a></td>
-    			<td class="span9">Diese Tasse enthält 179 der wichtigsten OSM-Tags als Gedankenstütze für den täglichen Gebrauch. Die Tasse ist spülmaschinenfest.<a target="_blank" href="http://shop.kernelconcepts.de/images/osm-mug-preview.png"> Der komplette Aufdruck.</a></td>
-    			<td>7,50€ (inkl. 1,30€ Spende)<br/><a target="_blank" href="http://shop.kernelconcepts.de/product_info.php?products_id=112">Zum Shop</a></td>
+				<td><a target="_blank" href="http://shop.kernelconcepts.de/#osm"><img width="80px" src="img/tasse-big.png" alt="OSM-Tasse" title="OSM Cheat Mug"/></a></td>
+				<td class="span9">Diese Tasse enthält 179 der wichtigsten OSM-Tags als Gedankenstütze für den täglichen Gebrauch. Die Tasse ist spülmaschinenfest.<a target="_blank" href="http://shop.kernelconcepts.de/img/osm-mug-preview.png"> Der komplette Aufdruck.</a></td>
+				<td>7,50€ (inkl. 1,30€ Spende)<br/><a target="_blank" href="http://shop.kernelconcepts.de/">Zum Shop</a></td>
     		</tr>
     	</table>
     	<p>


### PR DESCRIPTION
The shop has been down for at least two years now and replaced by an old-style ordering system via email. Orders via email are delivered, see a [posting](https://forum.openstreetmap.org/viewtopic.php?pid=615424#p615424) at the German OSM forum for reference.

I have deployed this [on my own server](https://michreichert.de/osm/openstreetmap.de/fan-artikel.html).