### PR TITLE
Add updated OSM user groups file

### DIFF
--- a/map_src/osm_user_groups_dach.kml
+++ b/map_src/osm_user_groups_dach.kml
@@ -1,3 +1,1038 @@
 <?xml version="1.0" encoding="utf-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">
-<Document><name>OSM usergroups</name><description>Generated list of OpenStreetMap local user groups by UserGroupsBot</description><Style id="usergroup"><IconStyle><Icon><href>localgroup.png</href><scale>0.5</scale></Icon></IconStyle></Style><Placemark id="0"><name>Karlsruhe</name><Point><coordinates>8.40752,49.00755</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Karlsruhe</wiki><url></url><country>DE</country><when>Jeden 3. Mittwoch im Monat</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/karlsruhe</mail><where></where></Placemark><Placemark id="1"><name>Hamburg</name><Point><coordinates>9.975725,53.56453</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Hamburger Mappertreffen</wiki><url></url><country>DE</country><when>jeden 2. Dienstag im Monat, 19 Uhr</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/hamburg</mail><where></where></Placemark><Placemark id="2"><name>Aschaffenburg</name><Point><coordinates>9.15441,49.97487</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Aschaffenburg</wiki><url></url><country>DE</country><when>kein fester Regeltermin</when><photo></photo><mail>mapper-osm-ab@postkammer.de</mail><where></where></Placemark><Placemark id="3"><name>Münster</name><Point><coordinates>7.64183,51.95445</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Münster</wiki><url></url><country>DE</country><when>vierteljährlich, am 2. Montag im Quartal</when><photo></photo><mail></mail><where></where></Placemark><Placemark id="4"><name>Schwäbisch Hall</name><Point><coordinates>9.7357,49.1117</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Schwäbisch Hall</wiki><url></url><country>DE</country><when>monatlich</when><photo></photo><mail>http://osm-sha.ingmars-bastelecke.net</mail><where></where></Placemark><Placemark id="5"><name>Dresden</name><Point><coordinates>13.731133,51.027051</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Stammtisch Dresden</wiki><url></url><country>DE</country><when>erster Donnerstag im Monat, ab 19:00 Uhr</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/dresden</mail><where></where></Placemark><Placemark id="6"><name>Würzburg</name><Point><coordinates>9.94649,49.78042</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Würzburg</wiki><url></url><country>DE</country><when>sporadic, if possible once a month: 16.12.2011 um 19 Uhr</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/wuerzburg</mail><where></where></Placemark><Placemark id="7"><name>Nürnberg/Fürth/Erlangen</name><Point><coordinates>11.08019256583,49.44937897891</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/NFE-Treffen</wiki><url></url><country>DE</country><when>Jeder letzte Donnerstag im Monat ab 19 Uhr</when><photo>http://wiki.openstreetmap.org/w/images/a/a5/Map_Franconia_1799.jpg</photo><mail>http://lists.openstreetmap.de/mailman/listinfo/franken</mail><where></where></Placemark><Placemark id="8"><name>Trierer Mappertreffen</name><Point><coordinates>6.651091,49.757326</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Trier</wiki><url></url><country>DE</country><when>unregelmäßig</when><photo></photo><mail></mail><where></where></Placemark><Placemark id="9"><name>Stammtisch Hannover</name><Point><coordinates>9.717395,52.386145</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Stammtisch Hannover</wiki><url></url><country>DE</country><when>alle 31 Tage</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/hannover</mail><where></where></Placemark><Placemark id="10"><name>Kreis Wesel</name><Point><coordinates>6.6223,51.6573</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Kreis Wesel</wiki><url></url><country>DE</country><when>unregelmäßig</when><photo></photo><mail></mail><where></where></Placemark><Placemark id="11"><name>Gruppe</name><Point><coordinates>8.7029,48.8936</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Pforzheim</wiki><url></url><country>DE</country><when></when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/pforzheim</mail><where></where></Placemark><Placemark id="12"><name>Fulda</name><Point><coordinates>9.66796,50.55112</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Fulda</wiki><url></url><country>DE</country><when>unregelmäßig</when><photo></photo><mail></mail><where></where></Placemark><Placemark id="13"><name>Mittelhessen (GI/LDK/LM/MR/VB)</name><Point><coordinates>8.606414794921875,50.64562901758801</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Stammtisch Mittelhessen</wiki><url>http://www.osm-mittelhessen.de</url><country>DE</country><when>geplant 27.12.11, 10:00Uhr</when><photo>http://wiki.openstreetmap.org/w/images/2/29/091021-OSM-Stammtisch-Mittelhessen-08.jpg</photo><mail></mail><where></where></Placemark><Placemark id="14"><name>Berlin und Brandenburg</name><Point><coordinates>13.418980,52.513332</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Berlin/Stammtisch</wiki><url></url><country>DE</country><when>2. Donnerstag im Monat ab 19.00 Uhr</when><photo></photo><mail>http://wiki.openstreetmap.org/wiki/Berlin/Diskussionsliste</mail><where></where></Placemark><Placemark id="15"><name>Ingolstadt</name><Point><coordinates>11.40861,48.76609</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Ingolstadt</wiki><url></url><country>DE</country><when>Jeden 3. Donnerstag im Monat</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/bayern</mail><where></where></Placemark><Placemark id="16"><name>Dortmund</name><Point><coordinates>7.48215,51.51329</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Mappertreffen Dortmund</wiki><url></url><country>DE</country><when>erster Sonntag im Monat, ab 19:00 Uhr</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/dortmund</mail><where></where></Placemark><Placemark id="17"><name>OSM Siegerland</name><Point><coordinates>8.017,50.876</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Siegen</wiki><url></url><country>DE</country><when></when><photo></photo><mail>http://www.unix-ag.uni-siegen.de/mailman/listinfo/osm-siegen</mail><where></where></Placemark><Placemark id="18"><name>OSM Stammtisch Leipzig und Halle</name><Point><coordinates>12.3788,51.3374</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Leipzig/Stammtisch</wiki><url></url><country>DE</country><when>no regular meetings</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/halleipzig/</mail><where></where></Placemark><Placemark id="19"><name>Stammtisch Erfurt</name><Point><coordinates>11.02935,50.9784</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Erfurt/Stammtisch</wiki><url></url><country>DE</country><when>unregelmäßig</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/thueringen</mail><where></where></Placemark><Placemark id="20"><name>Stuttgart</name><Point><coordinates>9.18219,48.77622</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Stuttgart/Stammtisch</wiki><url></url><country>DE</country><when></when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/stuttgart</mail><where></where></Placemark><Placemark id="21"><name>Lüneburg</name><Point><coordinates>10.40614,53.24804</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Lüneburg/Archiv2</wiki><url></url><country>DE</country><when>Jeden 3. Dienstag im Monat</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/luenebur</mail><where></where></Placemark><Placemark id="22"><name>Pirna</name><Point><coordinates>13.9454,50.9616</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Pirna/OSM-Treff</wiki><url></url><country>DE</country><when>unregelmässig</when><photo></photo><mail></mail><where></where></Placemark><Placemark id="23"><name>Ostwestfalen-Lippe</name><Point><coordinates>8.7352922,51.7136138</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/OWL-Treffen</wiki><url></url><country>DE</country><when>Thursday</when><photo></photo><mail>http://gt.owl.de/mailman/listinfo/osm</mail><where></where></Placemark><Placemark id="24"><name>Stammtisch Göttingen</name><Point><coordinates>9.930533,51.53483</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Göttingen/Stammtisch</wiki><url>http://goemap.de/ goemap.de</url><country>DE</country><when>Termine siehe Mailingliste</when><photo></photo><mail>https://lists.openstreetmap.de/mailman/listinfo/goettingen</mail><where></where></Placemark><Placemark id="25"><name>Städteregion Aachen</name><Point><coordinates>6.098,50.7681</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/DE:Aachen Community</wiki><url></url><country>DE</country><when>bisher nichts geplant</when><photo>http://upload.wikimedia.org/wikipedia/commons/4/4b/Wappen_Kreis_Aachen.svg</photo><mail>http://lists.openstreetmap.de/mailman/listinfo/aachen</mail><where></where></Placemark><Placemark id="26"><name>Main-Tauber-Kreis</name><Point><coordinates>9.7115,49.5601</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Main-Tauber-Kreis</wiki><url></url><country>DE</country><when></when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/main-tauber</mail><where></where></Placemark><Placemark id="27"><name>München</name><Point><coordinates>11.588736,48.122629</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/München/Treffen</wiki><url></url><country>DE</country><when>monatlich, Tag wechselt</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/bayern</mail><where></where></Placemark><Placemark id="28"><name>Wien</name><Point><coordinates>16.3664,48.1948</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Wien/Stammtisch</wiki><url>https://wiki.openstreetmap.org/wiki/Wien/Stammtisch Wiener Stammtisch</url><country>AT</country><when>jeden 1. Mittwoch in ungeraden Monaten</when><photo>http://wiki.openstreetmap.org/w/images/e/ee/WienerStammtisch_Jan2011.jpg</photo><mail>http://lists.openstreetmap.org/listinfo/talk-at</mail><where></where></Placemark><Placemark id="29"><name>Kleverland</name><Point><coordinates>6.134689,51.783352</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Kreis Kleve</wiki><url></url><country>DE</country><when>dritter Dienstag im Monat</when><photo></photo><mail></mail><where></where></Placemark><Placemark id="30"><name></name><Point><coordinates>9.2059,49.1394</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/OSM-Treff Heilbronn</wiki><url></url><country>DE</country><when>1. Dienstag im Monat, 19 Uhr</when><photo>http://wiki.openstreetmap.org/w/images/d/d7/OSM-Treff_HN.jpg</photo><mail>http://lists.openstreetmap.de/mailman/listinfo/unterland</mail><where></where></Placemark><Placemark id="31"><name>Rostocker Treffen</name><Point><coordinates>12.121773,54.088956</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Rostocker Treffen</wiki><url></url><country>DE</country><when>the 2nd monday per month</when><photo>http://wiki.openstreetmap.org/w/images/0/0e/MV_Mapping_Party_3_-_Das_Team.jpg</photo><mail>http://lists.openstreetmap.de/mailman/listinfo/meckpomm</mail><where></where></Placemark><Placemark id="32"><name>Köln</name><Point><coordinates>6.958622,50.92188</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Stammtisch Köln</wiki><url></url><country>DE</country><when>3. Mittwoch im Monat</when><photo></photo><mail></mail><where></where></Placemark><Placemark id="33"><name>Braunschweig</name><Point><coordinates>10.52015,52.26442</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Braunschweig/Stammtisch</wiki><url></url><country>DE</country><when>every 1st tuesday</when><photo></photo><mail>https://mail.atekon.de/mailman/listinfo/osm-bs</mail><where></where></Placemark><Placemark id="34"><name>Frankfurter OSM-Stammtisc</name><Point><coordinates>8.62613,50.13136</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Frankfurt am Main/OSM-Frühschoppen</wiki><url></url><country>DE</country><when>in geraden Monaten der 1. Mittwoch, in ungeraden Monaten der 1. Dienstag</when><photo>http://wiki.openstreetmap.org/w/images/3/3c/20090208fruehschoppen.jpg</photo><mail>http://lists.openstreetmap.de/mailman/listinfo/frankfurt</mail><where></where></Placemark><Placemark id="35"><name>Zittau</name><Point><coordinates>14.8120,50.8983</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/OSM-Stammtisch Zittau</wiki><url></url><country>DE</country><when>vierteljährlich</when><photo>http://wiki.openstreetmap.org/w/images/7/75/OSM-Stammtisch-Zittau.JPG</photo><mail></mail><where></where></Placemark><Placemark id="36"><name>OSM-Stammtisch-Odenwald</name><Point><coordinates>9.006511,49.670215</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/OSM-Stammtisch-Odenwald</wiki><url></url><country>DE</country><when>Nach Ankündigung</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/odenwald</mail><where></where></Placemark><Placemark id="37"><name>Esslingen</name><Point><coordinates>9.14196878671646,48.7011694908142</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Esslingen am Neckar</wiki><url></url><country>DE</country><when></when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/stuttgart</mail><where></where></Placemark><Placemark id="38"><name>Bonn</name><Point><coordinates>7.1212,50.707</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Bonn/Stammtisch</wiki><url>http://wiki.openstreetmap.org/wiki/Bonn/Stammtisch</url><country>DE</country><when>Jeden 4. Donnerstag im Monat</when><photo>http://wiki.openstreetmap.org/w/images/0/0c/Bonn_Stammtisch_OSM.jpg</photo><mail>http://lists.openstreetmap.de/mailman/listinfo/bonn-rhein-sieg</mail><where></where></Placemark><Placemark id="39"><name>Schorndorf</name><Point><coordinates>9.537932,48.807943</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Schorndorf/Treffen</wiki><url></url><country>DE</country><when>unregelmäßig</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/stuttgart</mail><where></where></Placemark><Placemark id="40"><name>Stammtisch Kreis Düren</name><Point><coordinates>6.4714279,50.7963018</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/DE:Kreis Düren Stammtisch</wiki><url></url><country>DE</country><when>Mittwochs Mitte des Monats</when><photo>http://wiki.openstreetmap.org/w/images/1/14/10062009257.jpg</photo><mail>http://lists.openstreetmap.de/mailman/listinfo/dueren</mail><where></where></Placemark><Placemark id="41"><name>Schweriner Treffen</name><Point><coordinates>11.40714,53.62877</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Schweriner Treffen</wiki><url></url><country>DE</country><when>halbjährlich</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/meckpomm</mail><where></where></Placemark><Placemark id="42"><name>Zürich</name><Point><coordinates>8.5467,47.37598</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/DE:Switzerland:Zürich/OSM-Treffen</wiki><url></url><country>CH</country><when>jeden 11. im Monat (ab 18 Uhr)</when><photo>http://wiki.openstreetmap.org/w/images/0/00/2_Mapping_Party_Rapperswil_klein.png</photo><mail>http://lists.openstreetmap.ch/mailman/listinfo/talk-ch</mail><where></where></Placemark><Placemark id="43"><name>Friedrichshafen</name><Point><coordinates>9.4784851,47.6519684</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Friedrichshafen-Bodensee Community</wiki><url></url><country>DE</country><when>Nach Ankündigung</when><photo></photo><mail>http://lists.djfun.de/listinfo/osm-fn</mail><where></where></Placemark><Placemark id="44"><name>OpenStreetMap Projekt Ostfriesland</name><Point><coordinates>7.481861,53.468407</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Ostfriesland</wiki><url></url><country>DE</country><when>wechselnd</when><photo>http://upload.wikimedia.org/wikipedia/commons/e/e4/Wkistammtischostfriesland2009.jpg</photo><mail>http://wiki.openstreetmap.org/wiki/Ostfriesland</mail><where></where></Placemark><Placemark id="45"><name>Salzburg</name><Point><coordinates>13.04747,47.81905</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Salzburg/Stammtisch</wiki><url>https://wiki.openstreetmap.org/wiki/Salzburg/Stammtisch Salzburger Stammtisch</url><country>AT</country><when>unregelmäßig</when><photo>http://wiki.openstreetmap.org/w/images/a/a5/Salzburg_stammtisch_19022010.jpg</photo><mail>http://lists.openstreetmap.org/listinfo/talk-at</mail><where></where></Placemark><Placemark id="46"><name>Reutlinger OSM-Treffen</name><Point><coordinates>9.203182,48.508432</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Reutlinger Treffen</wiki><url></url><country>DE</country><when></when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/neckar-alb</mail><where></where></Placemark><Placemark id="47"><name>Innsbruck</name><Point><coordinates>11.3282565,47.2517414</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Innsbruck/Stammtisch</wiki><url></url><country>AT</country><when>Monatsmitte, donnerstags</when><photo></photo><mail>http://lists.openstreetmap.org/listinfo/talk-at</mail><where></where></Placemark><Placemark id="48"><name></name><Point><coordinates>9.59737,47.23749</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Vorarlberg/Stammtisch</wiki><url></url><country>AT</country><when>auf Wunsch</when><photo></photo><mail>https://mailbox.4-mail.net/mailman/listinfo/osm-vlbg</mail><where></where></Placemark><Placemark id="49"><name>Viersen</name><Point><coordinates>6.38265,51.26596</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Niederrhein/Viersen/Stammtisch</wiki><url></url><country>DE</country><when>Dienstag ~Monatsmitte (xx.01.2012)</when><photo></photo><mail></mail><where></where></Placemark><Placemark id="50"><name>Düsseldorf</name><Point><coordinates>6.7976364,51.24124</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Düsseldorf/Stammtisch</wiki><url></url><country>DE</country><when>letzter Mittwoch im Monat, ab 19:00 Uhr</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/duesseldorf</mail><where></where></Placemark><Placemark id="51"><name>Augsburg</name><Point><coordinates>10.89728,48.36912</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Augsburg/Stammtisch</wiki><url></url><country>DE</country><when>08.12.2011 19:30</when><photo>http://wiki.openstreetmap.org/w/images/e/ef/Stammtisch-Augsburg.jpg</photo><mail>http://lists.openstreetmap.de/mailman/listinfo/augsburg</mail><where></where></Placemark><Placemark id="52"><name>Bremen</name><Point><coordinates>8.82185,53.07196</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Bremen/Mappertreffen</wiki><url></url><country>DE</country><when>alle 31 Tage</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/bremen</mail><where></where></Placemark><Placemark id="53"><name>Linz</name><Point><coordinates>14.3180,48.3364</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Linz/Stammtisch</wiki><url></url><country>AT</country><when>unregelmäßig (halbjährlich)</when><photo></photo><mail>http://lists.openstreetmap.org/listinfo/talk-at</mail><where></where></Placemark><Placemark id="54"><name>Bad Neuenahr-Ahrweiler</name><Point><coordinates>7.144457995891571,50.547233242805994</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Bad Neuenahr-Ahrweiler</wiki><url></url><country>DE</country><when>Jeden 2. Mittwoch im Monat 18.00 Uhr</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/bonn-rhein-sieg</mail><where></where></Placemark><Placemark id="55"><name>Stammtisch Darmstadt</name><Point><coordinates>8.6608925,49.871987</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Darmstadt/Stammtisch</wiki><url></url><country>DE</country><when>Quartalsrhythmus</when><photo></photo><mail></mail><where></where></Placemark><Placemark id="56"><name>Chaos Communication Congress</name><Point><coordinates>13.41674,52.52065</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Chaos Communication Congress</wiki><url>[http://events.ccc.de/congress/2011/wiki/OSM CCC Wiki]</url><country>DE</country><when>27.12-30.12. ab 8:00 Uhr</when><photo></photo><mail></mail><where></where></Placemark><Placemark id="57"><name>Mappertreffen Passau</name><Point><coordinates>13.462775,48.57298</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Passau/Mappertreffen</wiki><url></url><country>DE</country><when>2. Montag im Monat, 19:00 Uhr</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/niederbayern</mail><where></where></Placemark><Placemark id="58"><name></name><Point><coordinates>7.00712,51.45866</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Essen/OSM-Treffen</wiki><url></url><country>DE</country><when>Etwa monatlich</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/essen</mail><where></where></Placemark><Placemark id="59"><name>Graz</name><Point><coordinates>15.4330724,47.073193</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Graz/Stammtisch</wiki><url>http://wiki.openstreetmap.org/wiki/Graz/Stammtisch</url><country>AT</country><when>2. Hälfte der ungeraden Monate</when><photo>http://wiki.openstreetmap.org/w/images/d/d3/Osm_graz_members_2011.jpeg</photo><mail>http://lists.openstreetmap.org/listinfo/talk-at</mail><where></where></Placemark><Placemark id="60"><name>Mapper-Treffen Landshut</name><Point><coordinates>12.1492293477058,48.5370089113712</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Landshut Stammtisch</wiki><url>http://wiki.openstreetmap.org/wiki/Landshut</url><country>DE</country><when>2. Montag im Monat um 20:00 Uhr</when><photo>http://wiki.openstreetmap.org/w/images/5/5d/Landshuter_Stammtisch.png</photo><mail>http://lists.openstreetmap.de/mailman/listinfo/niederbayern</mail><where></where></Placemark><Placemark id="61"><name>Stammtisch Südlicher Thüringer Wald</name><Point><coordinates>11.14,50.509</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Südlicher Thüringer Wald/Stammtisch</wiki><url></url><country>DE</country><when></when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/thueringen</mail><where></where></Placemark><Placemark id="62"><name>Wiener Neustadt</name><Point><coordinates>16.2481,47.8383</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Wiener Neustadt/Stammtisch</wiki><url></url><country>AT</country><when>jeden 3. Donnerstag alle 3 Monate</when><photo></photo><mail>http://lists.openstreetmap.org/listinfo/talk-at</mail><where></where></Placemark><Placemark id="63"><name>Lüneburg</name><Point><coordinates>10.40614,53.24804</coordinates></Point><styleUrl>#usergroup</styleUrl><wiki>http://wiki.openstreetmap.org/wiki/Lüneburg/Mappertreffen</wiki><url></url><country>DE</country><when>Jeden 3. Dienstag im Monat</when><photo></photo><mail>http://lists.openstreetmap.de/mailman/listinfo/lueneburg</mail><where></where></Placemark></Document></kml>
+  <Document>
+    <name>OSM usergroups</name>
+    <description>Generated list of OpenStreetMap local user groups by UserGroupsBot</description>
+    <Style id="usergroup">
+      <IconStyle>
+        <Icon>
+          <href>localgroup.png</href>
+          <scale>0.5</scale>
+        </Icon>
+      </IconStyle>
+    </Style>
+    <Placemark id="0">
+      <name>Karlsruhe</name>
+      <Point>
+        <coordinates>8.40752,49.00755</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Karlsruhe</wiki>
+      <url/>
+      <country>DE</country>
+      <when>Jeden 3. Mittwoch im Monat, 19:00 Uhr</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/karlsruhe</mail>
+      <where>Normalerweise im &lt;a href="http://www.kleiner-ketterer.de/"&gt;Kleinen Ketterer&lt;/a&gt;</where>
+    </Placemark>
+    <Placemark id="13">
+      <name>Hamburg</name>
+      <Point>
+        <coordinates>9.975725,53.56453</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Hamburger Mappertreffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>jeden 2. Dienstag im Monat, 19 Uhr</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/hamburg</mail>
+      <where>&lt;a href="http://www.sternchance.de/"&gt;SternChance&lt;/a&gt; (im Dez. 2015: Bistro Chaplin, Rothenburgsort)</where>
+    </Placemark>
+    <Placemark id="14">
+      <name>Aschaffenburg</name>
+      <Point>
+        <coordinates>9.15441,49.97487</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Aschaffenburg</wiki>
+      <url/>
+      <country>DE</country>
+      <when>kein fester Regeltermin</when>
+      <photo/>
+      <mail>ashaffenburg@lists.openstreetmap.de</mail>
+      <where>Hofgarten</where>
+    </Placemark>
+    <Placemark id="15">
+      <name>Münster</name>
+      <Point>
+        <coordinates>7.6330177,51.9600508</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Münster</wiki>
+      <url/>
+      <country>DE</country>
+      <when>5. Juli 2016, 19:00 Uhr</when>
+      <photo/>
+      <mail/>
+      <where>&lt;a href="https://www.openstreetmap.org/node/622491517"&gt;BRASSERIE Münster&lt;/a&gt;</where>
+    </Placemark>
+    <Placemark id="16">
+      <name>Schwäbisch Hall</name>
+      <Point>
+        <coordinates>9.7357,49.1117</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Schwäbisch Hall</wiki>
+      <url/>
+      <country>DE</country>
+      <when>monatlich</when>
+      <photo/>
+      <mail>http://osm-sha.ingmars-bastelecke.net</mail>
+      <where>Altes Schlachthaus</where>
+    </Placemark>
+    <Placemark id="17">
+      <name>Dresden</name>
+      <Point>
+        <coordinates>13.7584689,51.0650740</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Stammtisch Dresden</wiki>
+      <url/>
+      <country>DE</country>
+      <when>erster Donnerstag im Monat, ab 19:00 Uhr</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/dresden</mail>
+      <where>Im Restaurant Diwan, Pulsnitzer Str. 18</where>
+    </Placemark>
+    <Placemark id="18">
+      <name>Würzburg</name>
+      <Point>
+        <coordinates>9.94649,49.78042</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Würzburg</wiki>
+      <url/>
+      <country>DE</country>
+      <when>sporadic, if possible once a month: 16.12.2011 um 19 Uhr</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/wuerzburg</mail>
+      <where>Schellingstr. 19, 97074 Würzburg</where>
+    </Placemark>
+    <Placemark id="20">
+      <name>Nürnberg/Fürth/Erlangen</name>
+      <Point>
+        <coordinates>11.08019256583,49.44937897891</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/NFE-Treffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>Jeder letzte Donnerstag im Monat ab 19 Uhr</when>
+      <photo>http://wiki.openstreetmap.org/w/images/a/a5/Map_Franconia_1799.jpg</photo>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/franken</mail>
+      <where>ARTEFAKT &lt;BR&gt; Johannesgasse 22, Nürnberg</where>
+    </Placemark>
+    <Placemark id="21">
+      <name>Trierer Mappertreffen</name>
+      <Point>
+        <coordinates>6.651091,49.757326</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Trier</wiki>
+      <url>http://wiki.openstreetmap.org/wiki/Trier/Mappertreffen</url>
+      <country>DE</country>
+      <when>unregelmäßig</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/trier</mail>
+      <where>Café Lecca</where>
+    </Placemark>
+    <Placemark id="22">
+      <name>Stammtisch Hannover</name>
+      <Point>
+        <coordinates>9.717395,52.386145</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Stammtisch Hannover</wiki>
+      <url/>
+      <country>DE</country>
+      <when>alle 31 Tage</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/hannover</mail>
+      <where>Klein Kröpcke, Callinstr. 2</where>
+    </Placemark>
+    <Placemark id="23">
+      <name>Kreis Wesel</name>
+      <Point>
+        <coordinates>6.6223,51.6573</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Kreis Wesel</wiki>
+      <url/>
+      <country>DE</country>
+      <when>unregelmäßig</when>
+      <photo/>
+      <mail/>
+      <where>verschieden</where>
+    </Placemark>
+    <Placemark id="25">
+      <name>Gruppe</name>
+      <Point>
+        <coordinates>8.7029,48.8936</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Pforzheim</wiki>
+      <url/>
+      <country>DE</country>
+      <when/>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/pforzheim</mail>
+      <where>Art Café oder Lehner's Wirtshaus</where>
+    </Placemark>
+    <Placemark id="26">
+      <name>Fulda</name>
+      <Point>
+        <coordinates>9.66796,50.55112</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Fulda</wiki>
+      <url/>
+      <country>DE</country>
+      <when>unregelmäßig</when>
+      <photo/>
+      <mail/>
+      <where>Wiesenmühle</where>
+    </Placemark>
+    <Placemark id="28">
+      <name>Mittelhessen (GI/LDK/LM/MR/VB)</name>
+      <Point>
+        <coordinates>8.606414794921875,50.64562901758801</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Stammtisch Mittelhessen</wiki>
+      <url>http://www.osm-mittelhessen.de</url>
+      <country>DE</country>
+      <when>geplant 27.12.11, 10:00Uhr</when>
+      <photo>http://wiki.openstreetmap.org/w/images/2/29/091021-OSM-Stammtisch-Mittelhessen-08.jpg</photo>
+      <mail/>
+      <where>Marburg</where>
+    </Placemark>
+    <Placemark id="29">
+      <name>Berlin und Brandenburg</name>
+      <Point>
+        <coordinates>13.41042,52.48840</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Berlin/Stammtisch</wiki>
+      <url>https://wiki.openstreetmap.org/wiki/Berlin/Stammtisch</url>
+      <country>DE</country>
+      <when>2. Donnerstag in ungeraden / &lt;br/&gt; 2. Freitag in geraden Monaten &lt;br/&gt;ab 19.00 Uhr</when>
+      <photo>http://wiki.openstreetmap.org/w/images/a/af/Logo_BerlinBrandenburg.svg</photo>
+      <mail>http://wiki.openstreetmap.org/wiki/Berlin/Diskussionsliste</mail>
+      <where>Resonanz, Ebersstraße 66, 10827 Berlin</where>
+    </Placemark>
+    <Placemark id="30">
+      <name>Ingolstadt</name>
+      <Point>
+        <coordinates>11.40861,48.76609</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Ingolstadt</wiki>
+      <url>http://wiki.openstreetmap.org/wiki/Ingolstadt#Stammtisch Ingolstadt</url>
+      <country>DE</country>
+      <when>Kein Termin vorhanden</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/bayern</mail>
+      <where>Café West</where>
+    </Placemark>
+    <Placemark id="32">
+      <name>Dortmund</name>
+      <Point>
+        <coordinates>7.40162,51.48321</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Mappertreffen Dortmund</wiki>
+      <url/>
+      <country>DE</country>
+      <when>normal erster Sonntag im Monat, ab 19:00 Uhr</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/dortmund</mail>
+      <where>Ping e.V., Zum Nubbental 11, Dortmund</where>
+    </Placemark>
+    <Placemark id="34">
+      <name>OSM Siegerland</name>
+      <Point>
+        <coordinates>8.017,50.876</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Siegen</wiki>
+      <url/>
+      <country>DE</country>
+      <when/>
+      <photo/>
+      <mail>http://www.unix-ag.uni-siegen.de/mailman/listinfo/osm-siegen</mail>
+      <where/>
+    </Placemark>
+    <Placemark id="35">
+      <name>OSM Stammtisch Leipzig und Halle</name>
+      <Point>
+        <coordinates>12.3788,51.3374</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Leipzig/Stammtisch</wiki>
+      <url/>
+      <country>DE</country>
+      <when>20. 5. 2014</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/halleipzig/</mail>
+      <where>Moritzbastei Leipzig</where>
+    </Placemark>
+    <Placemark id="36">
+      <name>Stammtisch Erfurt</name>
+      <Point>
+        <coordinates>11.02935,50.9784</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Erfurt/Stammtisch</wiki>
+      <url/>
+      <country>DE</country>
+      <when>unregelmäßig, wird über Mailingliste ermittelt</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/thueringen</mail>
+      <where>unterschiedlich, wird über Mailingliste geklärt</where>
+    </Placemark>
+    <Placemark id="37">
+      <name>Stuttgart</name>
+      <Point>
+        <coordinates>9.1610306,48.7693624</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Stuttgart/Stammtisch</wiki>
+      <url>http://wiki.openstreetmap.org/wiki/Stuttgart/Stammtisch</url>
+      <country>DE</country>
+      <when>jeden ersten Mittwoch im Monat um 19:00</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/stuttgart</mail>
+      <where>Zadu Bar</where>
+    </Placemark>
+    <Placemark id="39">
+      <name>Ostwestfalen-Lippe</name>
+      <Point>
+        <coordinates>8.75,52.1</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/OWL-Treffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>(see below)</when>
+      <photo/>
+      <mail>http://gt.owl.de/mailman/listinfo/osm</mail>
+      <where>(see below)</where>
+    </Placemark>
+    <Placemark id="40">
+      <name>Ostwestfalen/Lippe</name>
+      <Point>
+        <coordinates>8.7352922,51.7136138</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/OWL-Treffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>Thursday</when>
+      <photo/>
+      <mail>http://gt.owl.de/mailman/listinfo/osm</mail>
+      <where/>
+    </Placemark>
+    <Placemark id="41">
+      <name>Stammtisch Göttingen</name>
+      <Point>
+        <coordinates>9.930533,51.53483</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Göttingen/Stammtisch</wiki>
+      <url>http://goemap.de/ goemap.de</url>
+      <country>DE</country>
+      <when>Termine siehe Mailingliste</when>
+      <photo/>
+      <mail>https://lists.openstreetmap.de/mailman/listinfo/goettingen</mail>
+      <where>&lt;a href="http://www.cccgoe.de"&gt;noklab&lt;/a&gt;</where>
+    </Placemark>
+    <Placemark id="42">
+      <name>Städteregion Aachen</name>
+      <Point>
+        <coordinates>6.098,50.7681</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/DE:Aachen Community</wiki>
+      <url/>
+      <country>DE</country>
+      <when>bisher nichts geplant</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/aachen</mail>
+      <where>bisher nichts geplant</where>
+    </Placemark>
+    <Placemark id="43">
+      <name>Main-Tauber-Kreis</name>
+      <Point>
+        <coordinates>9.7115,49.5601</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Main-Tauber-Kreis</wiki>
+      <url/>
+      <country>DE</country>
+      <when/>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/main-tauber</mail>
+      <where>Lauda-Königshofen</where>
+    </Placemark>
+    <Placemark id="46">
+      <name>München</name>
+      <Point>
+        <coordinates>11.5439685,48.131847</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/München/Treffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>monatlich, Wochentag wechselt/ rolliert jeden 2. Dienstag-Donnerstag</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/bayern</mail>
+      <where>&lt;a href="http://www.wirtshaus-am-bavariapark.com/"&gt;Wirtshaus am Bavariapark&lt;/a&gt;</where>
+    </Placemark>
+    <Placemark id="47">
+      <name>Wien</name>
+      <Point>
+        <coordinates>16.368597,48.196342</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Wien/Stammtisch</wiki>
+      <url>https://wiki.openstreetmap.org/wiki/Wien/Stammtisch Wiener Stammtisch</url>
+      <country>AT</country>
+      <when>ca. jeden 1. Donnerstag im Monat&lt;!--</when>
+      <photo>http://wiki.openstreetmap.org/w/images/9/9d/Wiener_Stammtisch_2015.jpg</photo>
+      <mail>http://lists.openstreetmap.org/listinfo/talk-at</mail>
+      <where>Kartographie, TU Wien</where>
+    </Placemark>
+    <Placemark id="48">
+      <name>Kleverland</name>
+      <Point>
+        <coordinates>6.134689,51.783352</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Kreis Kleve</wiki>
+      <url/>
+      <country>DE</country>
+      <when>dritter Dienstag im Monat</when>
+      <photo/>
+      <mail/>
+      <where>Kolpinghaus Kleve</where>
+    </Placemark>
+    <Placemark id="49">
+      <name/>
+      <Point>
+        <coordinates>9.2059,49.1394</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/OSM-Treff Heilbronn</wiki>
+      <url/>
+      <country>DE</country>
+      <when>1. Dienstag im Monat, 19 Uhr</when>
+      <photo>http://wiki.openstreetmap.org/w/images/d/d7/OSM-Treff_HN.jpg</photo>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/unterland</mail>
+      <where>Wilhelm-Waiblinger-Haus</where>
+    </Placemark>
+    <Placemark id="50">
+      <name>Rostocker Treffen</name>
+      <Point>
+        <coordinates>12.121773,54.088956</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Rostocker Treffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>1. Dienstag, 19:00 Uhr</when>
+      <photo>http://wiki.openstreetmap.org/w/images/9/9a/OSM_MV2011_Hagenow_1.jpg</photo>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/meckpomm</mail>
+      <where>Plan B ''oder'' Freigarten.</where>
+    </Placemark>
+    <Placemark id="51">
+      <name>OSM-Stammtisch für Lübeck und Umgebung</name>
+      <Point>
+        <coordinates>10.68617,53.86831</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Lübecker Mappertreffen</wiki>
+      <url>http://www.osm-luebeck.de</url>
+      <country>DE</country>
+      <when>Jeden 4. Donnerstag im Monat</when>
+      <photo>http://wiki.openstreetmap.org/w/images/7/7c/20110407_osm_stammtisch_hl.jpg</photo>
+      <mail>https://lists.openstreetmap.de/mailman/listinfo/luebeck/</mail>
+      <where>Nobreakspace, Lübeck, Mengstraße</where>
+    </Placemark>
+    <Placemark id="52">
+      <name>Braunschweig</name>
+      <Point>
+        <coordinates>10.52114,52.27847</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Braunschweig/Stammtisch</wiki>
+      <url>https://stratum0.org/wiki/Hauptseite</url>
+      <country>DE</country>
+      <when>every 31 days</when>
+      <photo/>
+      <mail>https://mail.atekon.de/mailman/listinfo/osm-bs</mail>
+      <where>Stratum 0, Braunschweig, Hamburger Straße</where>
+    </Placemark>
+    <Placemark id="53">
+      <name>Frankfurter OSM-Stammtisch</name>
+      <Point>
+        <coordinates>8.62613,50.13136</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Frankfurt am Main/OSM-Frühschoppen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>in geraden Monaten der 1. Mittwoch, in ungeraden Monaten der 1. Dienstag</when>
+      <photo>http://wiki.openstreetmap.org/w/images/3/3c/20090208fruehschoppen.jpg</photo>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/frankfurt</mail>
+      <where>kp-21 (in der Brotfabrik)</where>
+    </Placemark>
+    <Placemark id="54">
+      <name>Zittau</name>
+      <Point>
+        <coordinates>14.8120,50.8983</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/OSM-Stammtisch Zittau</wiki>
+      <url/>
+      <country>DE</country>
+      <when>vierteljährlich</when>
+      <photo>http://wiki.openstreetmap.org/w/images/7/75/OSM-Stammtisch-Zittau.JPG</photo>
+      <mail/>
+      <where>&lt;a href="http://www.freiraumzittau.de"&gt;Wächterhaus Zittau&lt;/a&gt;</where>
+    </Placemark>
+    <Placemark id="56">
+      <name>OSM-Stammtisch-Odenwald</name>
+      <Point>
+        <coordinates>9.006511,49.670215</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/OSM-Stammtisch-Odenwald</wiki>
+      <url/>
+      <country>DE</country>
+      <when>Nach Ankündigung</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/odenwald</mail>
+      <where>Hotel Nibelungen, Taunusstraße 12 Michelstadt</where>
+    </Placemark>
+    <Placemark id="57">
+      <name>Esslingen</name>
+      <Point>
+        <coordinates>9.316,48.743</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Esslingen am Neckar</wiki>
+      <url>http://wiki.openstreetmap.org/wiki/Esslingen</url>
+      <country>DE</country>
+      <when/>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/stuttgart</mail>
+      <where/>
+    </Placemark>
+    <Placemark id="58">
+      <name>Bonn</name>
+      <Point>
+        <coordinates>7.1212,50.707</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Bonn/Stammtisch</wiki>
+      <url>http://wiki.openstreetmap.org/wiki/Bonn/Stammtisch Bonn/Stammtisch</url>
+      <country>DE</country>
+      <when>Jeden 3. Dienstag im Monat</when>
+      <photo>http://wiki.openstreetmap.org/w/images/0/0c/Bonn_Stammtisch_OSM.jpg</photo>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/bonn-rhein-sieg</mail>
+      <where>BTHV Gastronomie, Dottendorf</where>
+    </Placemark>
+    <Placemark id="61">
+      <name>Schorndorf</name>
+      <Point>
+        <coordinates>9.537932,48.807943</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Schorndorf/Treffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>17.07.2012 18 Uhr</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/stuttgart</mail>
+      <where>Schorndorf Manufaktur</where>
+    </Placemark>
+    <Placemark id="62">
+      <name>Stammtisch Kreis Düren</name>
+      <Point>
+        <coordinates>6.4714279,50.7963018</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/DE:Kreis Düren Stammtisch</wiki>
+      <url/>
+      <country>DE</country>
+      <when>unknown</when>
+      <photo>http://wiki.openstreetmap.org/w/images/1/14/10062009257.jpg</photo>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/dueren</mail>
+      <where>unknown</where>
+    </Placemark>
+    <Placemark id="63">
+      <name>Schweriner Treffen</name>
+      <Point>
+        <coordinates>11.40714,53.62877</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Schweriner Treffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>halbjährlich</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/meckpomm</mail>
+      <where>&lt;a href="http://www.myspace.com/subversivschwerin"&gt;Cafe Subversiv&lt;/a&gt;</where>
+    </Placemark>
+    <Placemark id="64">
+      <name>Zürich</name>
+      <Point>
+        <coordinates>8.5467,47.37598</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/DE:Switzerland:Zürich/OSM-Treffen</wiki>
+      <url>http://sosm.ch</url>
+      <country>CH</country>
+      <when>jeden 11. im Monat (ab 18:30 Uhr)</when>
+      <photo>http://wiki.openstreetmap.org/w/images/0/00/2_Mapping_Party_Rapperswil_klein.png</photo>
+      <mail>http://lists.openstreetmap.ch/mailman/listinfo/talk-ch</mail>
+      <where>beim Studi-Café bQm (ETH), Zürich</where>
+    </Placemark>
+    <Placemark id="65">
+      <name>Alto Adige - Südtirol</name>
+      <Point>
+        <coordinates>11.36,46.46</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/AltoAdige - Südtirol</wiki>
+      <url/>
+      <country>IT</country>
+      <when/>
+      <photo/>
+      <mail>http://lists.openstreetmap.org/listinfo/talk-it-southtyrol</mail>
+      <where/>
+    </Placemark>
+    <Placemark id="67">
+      <name>Friedrichshafen</name>
+      <Point>
+        <coordinates>9.4784851,47.6519684</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Friedrichshafen-Bodensee Community</wiki>
+      <url/>
+      <country>DE</country>
+      <when>Nach Ankündigung</when>
+      <photo/>
+      <mail/>
+      <where>88045 Friedrichshafen</where>
+    </Placemark>
+    <Placemark id="68">
+      <name>OpenStreetMap Projekt Ostfriesland</name>
+      <Point>
+        <coordinates>7.481861,53.468407</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Ostfriesland</wiki>
+      <url>http://wiki.openstreetmap.org/wiki/Ostfriesland</url>
+      <country>DE</country>
+      <when>wechselnd</when>
+      <photo>https://upload.wikimedia.org/wikipedia/commons/e/e4/Wkistammtischostfriesland2009.jpg</photo>
+      <mail/>
+      <where>Kattul, Aurich</where>
+    </Placemark>
+    <Placemark id="69">
+      <name>Salzburg</name>
+      <Point>
+        <coordinates>13.04747,47.81905</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Salzburg/Stammtisch</wiki>
+      <url>https://wiki.openstreetmap.org/wiki/Salzburg/Stammtisch Salzburger Stammtisch</url>
+      <country>AT</country>
+      <when>unregelmäßig</when>
+      <photo>http://wiki.openstreetmap.org/w/images/a/a5/Salzburg_stammtisch_19022010.jpg</photo>
+      <mail>http://lists.openstreetmap.org/listinfo/talk-at</mail>
+      <where>&lt;a href="http://www.zumgutenhirten.at/"&gt;Zum Guten Hirten&lt;/a&gt;</where>
+    </Placemark>
+    <Placemark id="70">
+      <name>Reutlinger OSM-Treffen</name>
+      <Point>
+        <coordinates>9.203182,48.508432</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Reutlinger Treffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when/>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/neckar-alb</mail>
+      <where>Gasthaus "Rancho Folclorico"</where>
+    </Placemark>
+    <Placemark id="71">
+      <name>Innsbruck</name>
+      <Point>
+        <coordinates>11.3282565,47.2517414</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Innsbruck/Stammtisch</wiki>
+      <url/>
+      <country>AT</country>
+      <when>Monatsmitte, donnerstags</when>
+      <photo>http://wiki.openstreetmap.org/w/images/c/c8/Stammtisch_Innsbruck_20121115a.jpg</photo>
+      <mail>http://lists.openstreetmap.org/listinfo/talk-at</mail>
+      <where>siehe &lt;a href="http://www.lugt.at/"&gt;lugt.at&lt;/a&gt;</where>
+    </Placemark>
+    <Placemark id="72">
+      <name/>
+      <Point>
+        <coordinates>9.59737,47.23749</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Vorarlberg/Stammtisch</wiki>
+      <url/>
+      <country>AT</country>
+      <when>auf Wunsch</when>
+      <photo/>
+      <mail>https://mailbox.4-mail.net/mailman/listinfo/osm-vlbg</mail>
+      <where>Cafe moebelle</where>
+    </Placemark>
+    <Placemark id="73">
+      <name>Viersen</name>
+      <Point>
+        <coordinates>6.3542868,51.2641128</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Niederrhein/Viersen/Stammtisch</wiki>
+      <url/>
+      <country>DE</country>
+      <when>Dienstag (xx.02.2017)</when>
+      <photo/>
+      <mail>mailto:osm-viersen@googlegroups.com</mail>
+      <where>&lt;a href="https://wiki.openstreetmap.org/wiki/http://www.zur-talquelle.de/ Zur Talquelle"&gt;http://www.zur-talquelle.de/ Zur Talquelle&lt;/a&gt;</where>
+    </Placemark>
+    <Placemark id="76">
+      <name>Düsseldorf</name>
+      <Point>
+        <coordinates>6.80181,51.21653</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Düsseldorf/Stammtisch</wiki>
+      <url/>
+      <country>DE</country>
+      <when>letzter Mittwoch/Freitag im Monat, ab 19:00 Uhr</when>
+      <photo/>
+      <mail>https://lists.openstreetmap.de/mailman/listinfo/duesseldorf</mail>
+      <where>Uerige am Markt</where>
+    </Placemark>
+    <Placemark id="77">
+      <name>Augsburg</name>
+      <Point>
+        <coordinates>10.89730,48.36917</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Augsburg/Stammtisch</wiki>
+      <url/>
+      <country>DE</country>
+      <when>19.01.17   20:00 Uhr</when>
+      <photo>http://wiki.openstreetmap.org/w/images/e/ef/Stammtisch-Augsburg.jpg</photo>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/augsburg</mail>
+      <where/>
+    </Placemark>
+    <Placemark id="53">
+      <name>Linz</name>
+      <Point>
+        <coordinates>14.28135,48.30874</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Linz/Stammtisch</wiki>
+      <url>http://wiki.openstreetmap.org/wiki/Linz/Stammtisch Linzer Stammtisch</url>
+      <country>AT</country>
+      <when>unregelmäßig (halbjährlich)</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.org/listinfo/talk-at</mail>
+      <where>Kulturverein Strandgut</where>
+    </Placemark>
+    <Placemark id="81">
+      <name>Luxembourg User Group</name>
+      <Point>
+        <coordinates>6.129768,49.604027</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/WikiProject Luxembourg</wiki>
+      <url>http://www.openstreetmap.lu</url>
+      <country>LU</country>
+      <when>on invitation</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.org/listinfo/talk-lu</mail>
+      <where>&lt;a href="http://www.crossfire.lu"&gt;Crossfire&lt;/a&gt;</where>
+    </Placemark>
+    <Placemark id="82">
+      <name>Stammtisch Darmstadt</name>
+      <Point>
+        <coordinates>8.6608925,49.871987</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Darmstadt/Stammtisch</wiki>
+      <url/>
+      <country>DE</country>
+      <when>Quartalsrhythmus</when>
+      <photo/>
+      <mail/>
+      <where/>
+    </Placemark>
+    <Placemark id="83">
+      <name>Mappertreffen Passau</name>
+      <Point>
+        <coordinates>13.462775,48.57298</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Passau/Mappertreffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>2. Montag im Monat, 19:00 Uhr</when>
+      <photo>http://wiki.openstreetmap.org/w/images/5/5d/Landshuter_Stammtisch.png</photo>
+      <mail>https://lists.openstreetmap.de/mailman/listinfo/niederbayern</mail>
+      <where>&lt;a href="http://www.kowalski.passau-live.de/"&gt;Café Kowalski&lt;/a&gt;</where>
+      <where/>
+    </Placemark>
+    <Placemark id="93">
+      <name>Essener OpenStreetMap Gruppe</name>
+      <Point>
+        <coordinates>7.00712,51.45866</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Essen/OSM-Treffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>Etwa monatlich</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/essen</mail>
+      <where>&lt;a href="https://wiki.openstreetmap.org/wiki/Essen/OSM-Treffen/Unperfekthau"&gt;Essen/OSM-Treffen/Unperfekthau&lt;/a&gt;[Essen/OSM-Treffen/Unperfekthaus</where>
+    </Placemark>
+    <Placemark id="94">
+      <name>Graz</name>
+      <Point>
+        <coordinates>15.4330724,47.073193</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Graz/Stammtisch</wiki>
+      <url>https://wiki.openstreetmap.org/wiki/Graz/Stammtisch</url>
+      <country>AT</country>
+      <when>4. Montag im Monat</when>
+      <photo>http://wiki.openstreetmap.org/w/images/d/d3/Osm_graz_members_2011.jpeg</photo>
+      <mail>https://lists.openstreetmap.org/listinfo/talk-at</mail>
+      <where>Brot&amp;Spiele</where>
+    </Placemark>
+    <Placemark id="95">
+      <name>Mapper-Treffen Landshut</name>
+      <Point>
+        <coordinates>12.1492293477058,48.5370089113712</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Landshut Stammtisch</wiki>
+      <url>http://wiki.openstreetmap.org/wiki/Landshut</url>
+      <country>DE</country>
+      <when>2. Dienstag im Monat um 20:00 Uhr</when>
+      <photo>http://wiki.openstreetmap.org/w/images/5/5d/Landshuter_Stammtisch.png</photo>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/niederbayern</mail>
+      <where>Gasthaus zur Insel</where>
+    </Placemark>
+    <Placemark id="97">
+      <name>Stammtisch Südlicher Thüringer Wald</name>
+      <Point>
+        <coordinates>11.1211313,50.5705153</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Südlicher Thüringer Wald/Stammtisch</wiki>
+      <url/>
+      <country>DE</country>
+      <when>noch offen</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/thueringen</mail>
+      <where/>
+    </Placemark>
+    <Placemark id="101">
+      <name>Wiener Neustadt</name>
+      <Point>
+        <coordinates>16.2481,47.8383</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Wiener Neustadt/Stammtisch</wiki>
+      <url/>
+      <country>AT</country>
+      <when>jeden 3. Donnerstag alle 3 Monate</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.org/listinfo/talk-at</mail>
+      <where/>
+    </Placemark>
+    <Placemark id="102">
+      <name>Lüneburg</name>
+      <Point>
+        <coordinates>10.40614,53.24804</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Lüneburg/Mappertreffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>Jeden 3. Dienstag im Monat</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/lueneburg</mail>
+      <where>Obere Schrangenstr. 23</where>
+    </Placemark>
+    <Placemark id="103">
+      <name>Schaumburger OpenStreetMap Gruppe</name>
+      <Point>
+        <coordinates>9.17013,52.28567</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Landkreis Schaumburg/OSM-Treffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>22.8.2016</when>
+      <photo/>
+      <mail/>
+      <where>Scarabeo Bückeburg</where>
+    </Placemark>
+    <Placemark id="104">
+      <name>Ulmer Alb</name>
+      <Point>
+        <coordinates>9.89174,48.54894</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/UlmerAlb</wiki>
+      <url>http://wiki.openstreetmap.org/wiki/UlmerAlb</url>
+      <country>DE</country>
+      <when>einmal monatlich 19:30 Uhr,&lt;br/&gt; meist dienstags oder donnerstags</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/ulmer-alb</mail>
+      <where>regulär: &lt;a href="http://www.openstreetmap.org/way/301484669"&gt;Hirsch Urspring&lt;/a&gt;,&lt;br /&gt; falls geschlossen: [https://www.openstreetmap.org/way/300421577 Halde]</where>
+    </Placemark>
+    <Placemark id="105">
+      <name>Bezirk Rohrbach</name>
+      <Point>
+        <coordinates>13.9474,48.7055</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Bezirk Rohrbach/Stammtisch</wiki>
+      <url>https://wiki.openstreetmap.org/wiki/Bezirk_Rohrbach/Stammtisch Stammtisch Bezirk Rohrbach</url>
+      <country>AT</country>
+      <when>unregelmäßig</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.org/listinfo/talk-at</mail>
+      <where>&lt;a href="http://www.innsholz.at/"&gt;INNs Holz&lt;/a&gt;, Schöneben bei Ulrichsberg</where>
+    </Placemark>
+    <Placemark id="106">
+      <name>Bremen</name>
+      <Point>
+        <coordinates>8.80562,53.08196</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Bremen/Veranstaltungen</wiki>
+      <url>http://osm-bremen.de</url>
+      <country>DE</country>
+      <when>Jeder vierte Montag im Monat</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/bremen</mail>
+      <where>&lt;a href="https://www.hackerspace-bremen.de/"&gt;Hackerspace Bremen&lt;/a&gt;</where>
+    </Placemark>
+    <Placemark id="107">
+      <name>Wermelskirchen</name>
+      <Point>
+        <coordinates>7.217149,51.138616</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Wermelskirchen/Stammtisch</wiki>
+      <url/>
+      <country>DE</country>
+      <when>Jeden 2. Donnerstag im Monat, 19:00 Uhr</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/bergisches-land</mail>
+      <where>Katt Bistro</where>
+    </Placemark>
+    <Placemark id="107">
+      <name>Hagen-Iserlohn und Umgebung</name>
+      <Point>
+        <coordinates>7.47605,51.35644</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Iserlohn und Hagen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>unregelmäßig</when>
+      <photo/>
+      <mail>http:</mail>
+      <where>Crocodile, Mittelstr., Hagen</where>
+    </Placemark>
+    <Placemark id="108">
+      <name>Landkreis Barnim</name>
+      <Point>
+        <coordinates>13.58236,52.68106</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Landkreis Barnim/Stammtisch</wiki>
+      <url/>
+      <country>DE</country>
+      <when>Anfangs per Umfrage</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/barnim</mail>
+      <where>Yellow (Mühlenstraße Ecke Alte Lohmühlenstraße)</where>
+    </Placemark>
+    <Placemark id="109">
+      <name>Chemnitz</name>
+      <Point>
+        <coordinates>12.917,50.83</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Stammtisch Chemnitz</wiki>
+      <url/>
+      <country>DE</country>
+      <when>28. jeden Monats</when>
+      <photo/>
+      <mail/>
+      <where>siehe ''nächster Termin''</where>
+    </Placemark>
+    <Placemark id="110">
+      <name>Leoben</name>
+      <Point>
+        <coordinates>15.1021,47.3643</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Leoben/Stammtisch</wiki>
+      <url>https://wiki.openstreetmap.org/wiki/Leoben/Stammtisch</url>
+      <country>AT</country>
+      <when>Quartalsweise, donnerstags, 18:00</when>
+      <photo/>
+      <mail>https://lists.openstreetmap.org/listinfo/talk-at</mail>
+      <where>"Zum Italo-Steierer"</where>
+    </Placemark>
+    <Placemark id="111">
+      <name>Ulm</name>
+      <Point>
+        <coordinates>9.991301,48.400625</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Ulm Neu-Ulm/Stammtisch</wiki>
+      <url>http://wiki.openstreetmap.org/wiki/Ulm_Neu-Ulm/Stammtisch Website des OSM-Stammtisch Ulm + Neu-Ulm</url>
+      <country>DE</country>
+      <when>Jeden 1. Dienstag im Monat -  7.2.2017 20:00</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/ulm</mail>
+      <where>&lt;a href="http://frrm.de"&gt;Freiraum Ulm&lt;/a&gt;, im Büchsenstadl über Radio free FM</where>
+    </Placemark>
+    <Placemark id="112">
+      <name>Mappertreffen Straubing</name>
+      <Point>
+        <coordinates>12.5672,48.87455</coordinates>
+      </Point>
+      <styleUrl>#usergroup</styleUrl>
+      <wiki>http://wiki.openstreetmap.org/wiki/Straubing/Mappertreffen</wiki>
+      <url/>
+      <country>DE</country>
+      <when>14.–27. Mai 2012</when>
+      <photo/>
+      <mail>http://lists.openstreetmap.de/mailman/listinfo/niederbayern</mail>
+      <where>Hotel Asam, Straubing</where>
+    </Placemark>
+  </Document>
+</kml>


### PR DESCRIPTION
This is a manual merge of all changes from [usersgroups.openstreetmap.de](http://usergroups.openstreetmap.de/osm_user_groups.kml). The file has been formatted using `xmllint --format` to make future manual merges easier if they will ever happen. :-) It increased the file by 5 kB, the further increase of 8 kB was caused by some new user groups.

See also https://lists.openstreetmap.org/pipermail/talk-de/2017-February/113785.html