### PR TITLE
Change tile urls of ÖPNV-Karte and OSM mapnik to https

### DIFF
--- a/map_src/js/map.js
+++ b/map_src/js/map.js
@@ -76,7 +76,7 @@ function init(){
 		{numZoomLevels: 19, attribution: '<a href="./germanstyle.html">About style</a>'}),
         new OpenLayers.Layer.OSM.CycleMap("Radfahrkarte (CycleMap)", {attribution:"", keyname: 'cycle'}),
         new OpenLayers.Layer.XYZ("&Ouml;PNV-Karte",
-			"http://tile.memomaps.de/tilegen/${z}/${x}/${y}.png",
+			"https://tile.memomaps.de/tilegen/${z}/${x}/${y}.png",
 			{numZoomLevels: 19, attribution:"", keyname: 'oepnvde'}),
         new OpenLayers.Layer.OSM.Mapnik("OSM Standard (Mapnik)", {attribution:"", keyname: 'mapnik'}),
     ]);

--- a/map_src/ol/OpenStreetMap.js
+++ b/map_src/ol/OpenStreetMap.js
@@ -14,9 +14,9 @@ OpenLayers.Layer.OSM.Mapnik = OpenLayers.Class(OpenLayers.Layer.OSM, {
      */
     initialize: function(name, options) {
         var url = [
-            "http://a.tile.openstreetmap.org/${z}/${x}/${y}.png",
-            "http://b.tile.openstreetmap.org/${z}/${x}/${y}.png",
-            "http://c.tile.openstreetmap.org/${z}/${x}/${y}.png"
+            "https://a.tile.openstreetmap.org/${z}/${x}/${y}.png",
+            "https://b.tile.openstreetmap.org/${z}/${x}/${y}.png",
+            "https://c.tile.openstreetmap.org/${z}/${x}/${y}.png"
         ];
         options = OpenLayers.Util.extend({
             numZoomLevels: 19,


### PR DESCRIPTION
ÖPNV-Karte and OSM mapnik tile servers also offer https, which leaves just opencyclemap as source for insecure connection warning in browsers.