### PR TITLE
Revert "Banner für bleibtoffen.de"

### DIFF
--- a/css/mystyle.css
+++ b/css/mystyle.css
@@ -32,17 +32,6 @@ div.black-warning li {
 }
 
 /* css for general use*/
-/* banner bleibtoffen.de */
-#bleibtoffen-banner {
-       display: block;
-       font-size: 18px;
-       background-color: #d3eeb4;
-       color: black;
-       padding: 7px 15px 8px 15px;
-       text-align: center;
-       height: 66px;
-       line-height: 66px;
-}
 
 #logo {
 	float: left;

--- a/index.html
+++ b/index.html
@@ -72,9 +72,6 @@ jQuery(document).ready(function() {
 
 
 </head>
-<div id="bleibtoffen-banner">
-    <a href="http://bleibtoffen.de">Bleibt Offen</a> sammelt Sonder-Öffnungszeiten mit <a href="https://wiki.openstreetmap.org/wiki/DE:Key:opening_hours:covid19">speziellen Tags</a> während der Covid19-Krise. Helft mit beim Mappen!
-</div>
 
 <div class="container">
 

--- a/karte.html
+++ b/karte.html
@@ -40,10 +40,6 @@
 </head>
 
 <body onload="init()">
-    <div id="bleibtoffen-banner">
-    <a href="http://bleibtoffen.de">Bleibt Offen</a> sammelt Sonder-Öffnungszeiten mit <a href="https://wiki.openstreetmap.org/wiki/DE:Key:opening_hours:covid19">speziellen Tags</a> während der Covid19-Krise. Helft mit beim Mappen!
-    </div>
-
     <div id="karte_nav">
         <ul class="lnav">
             <li><a href="index.html">Startseite</a></li>
@@ -56,6 +52,7 @@
             <li><a href="https://www.fossgis.de/datenschutzerklärung/">Datenschutz</a></li>
         </ul>
     </div>
+
     <div id="controls-row">
         <a href="index.html" id="osm_logo_link"><img id="osm_logo" src="img/osm_logo.png" alt="OSM-Logo"/></a>
 

--- a/map_src/style.css
+++ b/map_src/style.css
@@ -12,15 +12,6 @@ body {
 	align-content: stretch;
 }
 
-/* banner bleibtoffen.de */
-#bleibtoffen-banner {
-       font-size: 18px;
-       background-color: #d3eeb4ff;
-       color: black;
-       padding: 5px 10px 5px 10px;
-       text-align: center;
-}
-
 div.olControlLayerSwitcher {
 	width: 240px;	
 	font-size: 13px;


### PR DESCRIPTION
Die Ladengeschäfte dürfen schon seit einer Weile wieder öffnen und Lockdowns sind derzeit eine regionale Angelegenheit. Um die Website gepflegter wirken zu lassen, mache ich den Banner-Commit hiermit wieder rückgängig.

This reverts commit f58fa0fc6e2ff9ddd2daf0a5a77e5cd13cce1e56.