### PR TITLE
Fix typo in shop-window.html

### DIFF
--- a/layouts/shortcodes/shop-window.html
+++ b/layouts/shortcodes/shop-window.html
@@ -1,7 +1,7 @@
 
         <div class="tab" id="myDropdown">
             <button class="tablinks" onclick="openTab(event, 'Maps')" id="defaultOpen">Karten</button>
-            <button class="tablinks" onclick="openTab(event, 'Devices')">Mobile Gerätes</button>
+            <button class="tablinks" onclick="openTab(event, 'Devices')">Mobile Geräte</button>
             <button class="tablinks" onclick="openTab(event, 'Look')">Zum Anschauen</button>
             <button class="tablinks" onclick="openTab(event, 'Try')">Zum Ausprobieren</button>
             <button class="icon" onclick="toggleDropdown()"><i class="fa fa-caret-down" aria-hidden="true"></i></button>


### PR DESCRIPTION
Fixes a small typo `"Mobile Gerätes"` => `"Mobile Geräte"`.