### PR TITLE
Switch german style to ptolemy (new tile server)

### DIFF
--- a/map_src/js/map.js
+++ b/map_src/js/map.js
@@ -69,11 +69,7 @@ function init(){
 
 	//Add Layers
     map.addLayers([
-       new OpenLayers.Layer.XYZ("OSM deutscher Stil", [
-               "https://a.tile.openstreetmap.de/${z}/${x}/${y}.png",
-               "https://b.tile.openstreetmap.de/${z}/${x}/${y}.png",
-               "https://c.tile.openstreetmap.de/${z}/${x}/${y}.png",
-               "https://d.tile.openstreetmap.de/${z}/${x}/${y}.png"],
+       new OpenLayers.Layer.XYZ("OSM deutscher Stil", ["https://ptolemy.openstreetmap.de/${z}/${x}/${y}.png"],
 		{numZoomLevels: 20, attribution: '<a href="./germanstyle.html">About style</a>'}),
         new OpenLayers.Layer.XYZ("&Ouml;PNV-Karte",
 			"https://tile.memomaps.de/tilegen/${z}/${x}/${y}.png",


### PR DESCRIPTION
To get some traffic to the new tile server for testing, we switch the tile url for the german style on openstreetmap.de which accounts for about 10% of tile traffic

This is temporary and will be reverted when all traffic is on the new servers, or sooner if something goes wrong.