### PR TITLE
Switch german style to ptolemy (new tile server)

### DIFF
--- a/content/germanstyle.md
+++ b/content/germanstyle.md
@@ -100,3 +100,5 @@ nichtkommerzielle Zwecke erlauben. Kleinere Webanwendungen, wie z.B. der
 Anfahrtsplan auf der Firmenwebseite dürfen die Kacheln
 selbstverständlich verwenden. Bitte beachten sie auch die [Tile usage
 policy](https://wiki.openstreetmap.org/wiki/Tile_usage_policy).
+[Ausführlichere Informationen zu den Nutzungsbedingungen finden Sie 
+hier.](https://fossgis.de/arbeitsgruppen/osm-server/nutzungsbedingungen/)

--- a/static/karte/js/map.js
+++ b/static/karte/js/map.js
@@ -69,11 +69,7 @@ function init(){
 
 	//Add Layers
     map.addLayers([
-       new OpenLayers.Layer.XYZ("OSM deutscher Stil", [
-               "https://a.tile.openstreetmap.de/${z}/${x}/${y}.png",
-               "https://b.tile.openstreetmap.de/${z}/${x}/${y}.png",
-               "https://c.tile.openstreetmap.de/${z}/${x}/${y}.png",
-               "https://d.tile.openstreetmap.de/${z}/${x}/${y}.png"],
+       new OpenLayers.Layer.XYZ("OSM deutscher Stil", ["https://ptolemy.openstreetmap.de/${z}/${x}/${y}.png"],
 		{numZoomLevels: 20, attribution: '<a href="/germanstyle.html">About style</a>'}),
         new OpenLayers.Layer.XYZ("&Ouml;PNV-Karte",
 			"https://tile.memomaps.de/tilegen/${z}/${x}/${y}.png",


### PR DESCRIPTION
To get some traffic to the new tile server for testing, we switch the tile url for the german style on openstreetmap.de which accounts for about 10% of tile traffic

This is temporary and will be reverted when all traffic is on the new servers, or sooner if something goes wrong.