### PR TITLE
tippfehler "bischen" korrigiert

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -108,7 +108,7 @@ Europe**](https://stateofthemap.eu/).
 
 Im [OpenStreetMap-Wiki](https://wiki.openstreetmap.org/wiki/Hauptseite)
 dokumentieren wir alles, was so mit OSM zu tun hat. Vieles dort ist so ein
-bischen unaufgeräumt und teilweise auch veraltet, aber es gibt viele
+bisschen unaufgeräumt und teilweise auch veraltet, aber es gibt viele
 Informationen nur dort.
 
 [Deutsche Startseite](https://wiki.openstreetmap.org/wiki/Hauptseite) des Wikis

--- a/content/community/data-working-group.md
+++ b/content/community/data-working-group.md
@@ -33,9 +33,9 @@ Mehr über die Arbeit der DWG auf der Seite der OSM Foundation zur
 
 {{% infobox %}}
 
-Übrigens: Die Data Working Group kann immer Hilfe gebrauchen. Ein bischen
+Übrigens: Die Data Working Group kann immer Hilfe gebrauchen. Ein bisschen
 Erfahrung mit OSM gehört schon dazu, man sollte die Kultur bei OSM kennen
-und ein bischen Fingerspitzengefühl im Umgang mit einer Community von
+und ein bisschen Fingerspitzengefühl im Umgang mit einer Community von
 Freiwilligen haben.
 
 {{% /infobox %}}


### PR DESCRIPTION
"bischen" ist ein schwaches Verb und heisst "hin- und herwiegen" ;)