### PR TITLE
fix aria-hidden

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -102,7 +102,7 @@ Europe**](https://stateofthemap.eu/).
 
 ## Das OpenStreetMap-Wiki
 
-<img src="/img/osm_logo_wiki.png" alt="" aria-ignore="true" style="float: right; margin-left: 20px;"/>
+<img src="/img/osm_logo_wiki.png" alt="" aria-hidden="true" style="float: right; margin-left: 20px;"/>
 
 Im [OpenStreetMap-Wiki](https://wiki.openstreetmap.org/wiki/Hauptseite)
 dokumentieren wir alles, was so mit OSM zu tun hat. Vieles dort ist so ein

--- a/layouts/shortcodes/weekly-osm.html
+++ b/layouts/shortcodes/weekly-osm.html
@@ -1,5 +1,5 @@
 <a id="weekly-osm" href="https://weeklyosm.eu/de/" target="_blank">
     <div><b>OSM-Wochennotiz</b></div>
-    <img src="/img/weekly-osm.svg" alt="" aria-ignore="true"/>
+    <img src="/img/weekly-osm.svg" alt="" aria-hidden="true"/>
     <div>Neuigkeiten aus der<br/>OpenStreetMap-Welt</div>
 </a>


### PR DESCRIPTION
I believe there's no `aria-ignore` attribute — at least it's not listed here:

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes

From what I understand, `aria-hidden` is the correct attribute to use:

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden