### PR TITLE
a11y mobil nav

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -60,6 +60,18 @@ nav {
     background-color: var(--grey);
 }
 
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 @media screen and (min-width: 981px) {
     nav {
         display: flex !important;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -60,18 +60,6 @@ nav {
     background-color: var(--grey);
 }
 
-.visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-}
-
 @media screen and (min-width: 981px) {
     nav {
         display: flex !important;

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -5,5 +5,5 @@
         {{- end -}}
         <a class="nav-link{{- if or ($.IsMenuCurrent .Menu .) ($.HasMenuCurrent .Menu .) }} nav-link-active{{- end -}}{{- if ge .Weight 10 }} nav-link-short" title="{{ .Name }}{{- end -}}" href="{{ .URL | relURL }}"{{- if $.IsMenuCurrent .Menu . }} aria-current="page"{{ end }}{{- if $.HasMenuCurrent .Menu . }} aria-current="true"{{ end }}>{{ with resources.Get (printf "icons/%s.svg" .Page.Section) }}{{ .Content | safeHTML }}{{ end }} <span>{{ .Name }}</span></a>
         {{ end -}}
-        <a href="#" id="menu-toggle" class="icon"><span class="visually-hidden">Menü öffnen</span><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512"><path d="M64,384H448V341.33H64Zm0-106.67H448V234.67H64ZM64,128v42.67H448V128Z"/></svg></a>
+        <a href="#" id="menu-toggle" class="icon" aria-label="Menü umschalten"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512"><path d="M64,384H448V341.33H64Zm0-106.67H448V234.67H64ZM64,128v42.67H448V128Z"/></svg></a>
     </nav>

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -5,5 +5,5 @@
         {{- end -}}
         <a class="nav-link{{- if or ($.IsMenuCurrent .Menu .) ($.HasMenuCurrent .Menu .) }} nav-link-active{{- end -}}{{- if ge .Weight 10 }} nav-link-short" title="{{ .Name }}{{- end -}}" href="{{ .URL | relURL }}"{{- if $.IsMenuCurrent .Menu . }} aria-current="page"{{ end }}{{- if $.HasMenuCurrent .Menu . }} aria-current="true"{{ end }}>{{ with resources.Get (printf "icons/%s.svg" .Page.Section) }}{{ .Content | safeHTML }}{{ end }} <span>{{ .Name }}</span></a>
         {{ end -}}
-        <a href="#" id="menu-toggle" class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512"><path d="M64,384H448V341.33H64Zm0-106.67H448V234.67H64ZM64,128v42.67H448V128Z"/></svg></a>
+        <a href="#" id="menu-toggle" class="icon"><span class="visually-hidden">Menü öffnen</span><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512"><path d="M64,384H448V341.33H64Zm0-106.67H448V234.67H64ZM64,128v42.67H448V128Z"/></svg></a>
     </nav>


### PR DESCRIPTION
Das Hamburger-Menü der mobilen Navigation ist für Screenreader bislang nicht zugänglich, da es keinen beschreibenden Text enthält. Ich habe einen versteckten Text ergänzt, der von Screenreadern erkannt und vorgelesen wird. Dabei habe ich mich an [Bootstrap](https://github.com/twbs/bootstrap/blob/main/dist/css/bootstrap.css#L7144) orientiert.
